### PR TITLE
Added AvroCompatibilityHelper(https://github.com/linkedin/avro-util) support on Hive 1.0.1 to help hive consumers upgrade to higher Avro version

### DIFF
--- a/hbase-handler/pom.xml
+++ b/hbase-handler/pom.xml
@@ -61,7 +61,12 @@
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
       <version>1.7.6</version>
-	</dependency>
+	  </dependency>
+    <dependency>
+      <groupId>com.linkedin.avroutil1</groupId>
+      <artifactId>helper-all</artifactId>
+      <version>${avroHelper.version}</version>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/hbase-handler/src/java/org/apache/hadoop/hive/hbase/HBaseSerDeHelper.java
+++ b/hbase-handler/src/java/org/apache/hadoop/hive/hbase/HBaseSerDeHelper.java
@@ -19,6 +19,8 @@ package org.apache.hadoop.hive.hbase;
 
 import static org.apache.hadoop.hive.hbase.HBaseSerDeParameters.AVRO_SERIALIZATION_TYPE;
 
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
+import com.linkedin.avroutil1.compatibility.SchemaParseConfiguration;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -359,7 +361,7 @@ public class HBaseSerDeHelper {
     try {
       fs = FileSystem.get(new URI(schemaFSUrl), conf);
       in = fs.open(new Path(schemaFSUrl));
-      Schema s = Schema.parse(in);
+      Schema s = AvroCompatibilityHelper.parse(in, SchemaParseConfiguration.LOOSE, null).getMainSchema();
       return s;
     } catch (URISyntaxException e) {
       throw new SerDeException("Failure reading schema from filesystem", e);
@@ -468,7 +470,7 @@ public class HBaseSerDeHelper {
    * */
   private static void generateAvroStructFromSchema(String schemaLiteral, StringBuilder sb)
       throws SerDeException {
-    Schema schema = Schema.parse(schemaLiteral);
+    Schema schema = AvroCompatibilityHelper.parse(schemaLiteral);
 
     generateAvroStructFromSchema(schema, sb);
   }

--- a/hbase-handler/src/java/org/apache/hadoop/hive/hbase/HBaseSerDeParameters.java
+++ b/hbase-handler/src/java/org/apache/hadoop/hive/hbase/HBaseSerDeParameters.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.hive.hbase;
 
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -332,7 +333,7 @@ public class HBaseSerDeParameters {
       if (avroSchemaRetClass == null) {
         // bother about generating a schema only if a schema retriever class wasn't provided
         if (schemaLiteral != null) {
-          schema = Schema.parse(schemaLiteral);
+          schema = AvroCompatibilityHelper.parse(schemaLiteral);
         } else if (schemaUrl != null) {
           schema = HBaseSerDeHelper.getSchemaFromFS(schemaUrl, conf);
         } else if (deserializerClass != null) {

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
     <ant.version>1.9.1</ant.version>
     <antlr.version>3.4</antlr.version>
     <avro.version>1.7.5</avro.version>
-    <avroHelper.version>0.2.48</avroHelper.version>
+    <avroHelper.version>0.2.71</avroHelper.version>
     <bonecp.version>0.8.0.RELEASE</bonecp.version>
     <datanucleus-api-jdo.version>3.2.6</datanucleus-api-jdo.version>
     <datanucleus-core.version>3.2.10</datanucleus-core.version>

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,7 @@
     <ant.version>1.9.1</ant.version>
     <antlr.version>3.4</antlr.version>
     <avro.version>1.7.5</avro.version>
+    <avroHelper.version>0.2.48</avroHelper.version>
     <bonecp.version>0.8.0.RELEASE</bonecp.version>
     <datanucleus-api-jdo.version>3.2.6</datanucleus-api-jdo.version>
     <datanucleus-core.version>3.2.10</datanucleus-core.version>
@@ -166,6 +167,19 @@
   </properties>
 
   <repositories>
+    <repository>
+      <id>avro-util-repository</id>
+      <name>Avro util repository</name>
+      <url>https://linkedin.jfrog.io/artifactory/avro-util</url>
+      <layout>default</layout>
+      <releases>
+        <enabled>true</enabled>
+        <checksumPolicy>warn</checksumPolicy>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
     <repository>
       <id>datanucleus</id>
       <name>datanucleus maven repository</name>

--- a/serde/pom.xml
+++ b/serde/pom.xml
@@ -66,6 +66,11 @@
       <version>${avro.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.linkedin.avroutil1</groupId>
+      <artifactId>helper-all</artifactId>
+      <version>${avroHelper.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.thrift</groupId>
       <artifactId>libthrift</artifactId>
       <version>${libthrift.version}</version>

--- a/serde/src/java/org/apache/hadoop/hive/serde2/avro/AvroDeserializer.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/avro/AvroDeserializer.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hive.serde2.avro;
 
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -241,7 +242,8 @@ class AvroDeserializer {
 
       int scale = 0;
       try {
-        scale = fileSchema.getJsonProp(AvroSerDe.AVRO_PROP_SCALE).getIntValue();
+        scale = Integer.parseInt(AvroCompatibilityHelper.getSchemaPropAsJsonString(fileSchema, AvroSerDe.AVRO_PROP_SCALE,
+            false, false));
       } catch(Exception ex) {
         throw new AvroSerdeException("Failed to obtain scale value from file schema: " + fileSchema, ex);
       }
@@ -257,7 +259,8 @@ class AvroDeserializer {
 
       int maxLength = 0;
       try {
-        maxLength = fileSchema.getJsonProp(AvroSerDe.AVRO_PROP_MAX_LENGTH).getValueAsInt();
+        maxLength = Integer.parseInt(AvroCompatibilityHelper.getSchemaPropAsJsonString(fileSchema, AvroSerDe.AVRO_PROP_MAX_LENGTH,
+            false, false));
       } catch (Exception ex) {
         throw new AvroSerdeException("Failed to obtain maxLength value for char field from file schema: " + fileSchema, ex);
       }
@@ -272,7 +275,8 @@ class AvroDeserializer {
 
       maxLength = 0;
       try {
-        maxLength = fileSchema.getJsonProp(AvroSerDe.AVRO_PROP_MAX_LENGTH).getValueAsInt();
+        maxLength = Integer.parseInt(AvroCompatibilityHelper.getSchemaPropAsJsonString(fileSchema, AvroSerDe.AVRO_PROP_MAX_LENGTH,
+            false, false));
       } catch (Exception ex) {
         throw new AvroSerdeException("Failed to obtain maxLength value for varchar field from file schema: " + fileSchema, ex);
       }

--- a/serde/src/java/org/apache/hadoop/hive/serde2/avro/AvroSerdeUtils.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/avro/AvroSerdeUtils.java
@@ -17,7 +17,10 @@
  */
 package org.apache.hadoop.hive.serde2.avro;
 
-
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
+import com.linkedin.avroutil1.compatibility.SchemaParseConfiguration;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import org.apache.avro.Schema;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -227,27 +230,23 @@ public class AvroSerdeUtils {
   }
 
   public static Schema getSchemaFor(String str) {
-    Schema.Parser parser = new Schema.Parser();
-    Schema schema = parser.parse(str);
-    return schema;
+    return AvroCompatibilityHelper.parse(str);
   }
 
   public static Schema getSchemaFor(File file) {
-    Schema.Parser parser = new Schema.Parser();
-    Schema schema;
+    InputStream targetStream = null;
     try {
-      schema = parser.parse(file);
-    } catch (IOException e) {
-      throw new RuntimeException("Failed to parse Avro schema from " + file.getName(), e);
+      targetStream = new FileInputStream(file);
+    } catch (FileNotFoundException e) {
+      throw new RuntimeException("Failed to parse Avro schema from file due to the file (" + file.getAbsolutePath() + ") not found.", e);
     }
-    return schema;
+    return getSchemaFor(targetStream);
   }
 
   public static Schema getSchemaFor(InputStream stream) {
-    Schema.Parser parser = new Schema.Parser();
     Schema schema;
     try {
-      schema = parser.parse(stream);
+      schema = AvroCompatibilityHelper.parse(stream, SchemaParseConfiguration.LOOSE, null).getMainSchema();
     } catch (IOException e) {
       throw new RuntimeException("Failed to parse Avro schema", e);
     }

--- a/serde/src/java/org/apache/hadoop/hive/serde2/avro/AvroSerializer.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/avro/AvroSerializer.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hive.serde2.avro;
 
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -187,7 +188,7 @@ class AvroSerializer {
       if (schema.getType() == Type.BYTES){
         return AvroSerdeUtils.getBufferFromBytes((byte[])fieldOI.getPrimitiveJavaObject(structFieldData));
       } else if (schema.getType() == Type.FIXED){
-        Fixed fixed = new GenericData.Fixed(schema, (byte[])fieldOI.getPrimitiveJavaObject(structFieldData));
+        Fixed fixed = AvroCompatibilityHelper.newFixedField(schema, (byte[])fieldOI.getPrimitiveJavaObject(structFieldData));
         return fixed;
       } else {
         throw new AvroSerdeException("Unexpected Avro schema for Binary TypeInfo: " + schema.getType());

--- a/serde/src/java/org/apache/hadoop/hive/serde2/avro/SchemaToTypeInfo.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/avro/SchemaToTypeInfo.java
@@ -27,6 +27,7 @@ import static org.apache.avro.Schema.Type.LONG;
 import static org.apache.avro.Schema.Type.NULL;
 import static org.apache.avro.Schema.Type.STRING;
 
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Hashtable;
@@ -113,8 +114,10 @@ class SchemaToTypeInfo {
       int precision = 0;
       int scale = 0;
       try {
-        precision = schema.getJsonProp(AvroSerDe.AVRO_PROP_PRECISION).getIntValue();
-        scale = schema.getJsonProp(AvroSerDe.AVRO_PROP_SCALE).getIntValue();
+        precision = Integer.parseInt(AvroCompatibilityHelper.getSchemaPropAsJsonString(schema, AvroSerDe.AVRO_PROP_PRECISION,
+            false, false));
+        scale = Integer.parseInt(AvroCompatibilityHelper.getSchemaPropAsJsonString(schema, AvroSerDe.AVRO_PROP_SCALE,
+            false, false));
       } catch (Exception ex) {
         throw new AvroSerdeException("Failed to obtain scale value from file schema: " + schema, ex);
       }
@@ -132,7 +135,8 @@ class SchemaToTypeInfo {
         AvroSerDe.CHAR_TYPE_NAME.equalsIgnoreCase(schema.getProp(AvroSerDe.AVRO_PROP_LOGICAL_TYPE))) {
       int maxLength = 0;
       try {
-        maxLength = schema.getJsonProp(AvroSerDe.AVRO_PROP_MAX_LENGTH).getValueAsInt();
+        maxLength = Integer.parseInt(AvroCompatibilityHelper.getSchemaPropAsJsonString(schema, AvroSerDe.AVRO_PROP_MAX_LENGTH,
+            false, false));
       } catch (Exception ex) {
         throw new AvroSerdeException("Failed to obtain maxLength value from file schema: " + schema, ex);
       }
@@ -143,7 +147,8 @@ class SchemaToTypeInfo {
         AvroSerDe.VARCHAR_TYPE_NAME.equalsIgnoreCase(schema.getProp(AvroSerDe.AVRO_PROP_LOGICAL_TYPE))) {
       int maxLength = 0;
       try {
-        maxLength = schema.getJsonProp(AvroSerDe.AVRO_PROP_MAX_LENGTH).getValueAsInt();
+        maxLength = Integer.parseInt(AvroCompatibilityHelper.getSchemaPropAsJsonString(schema, AvroSerDe.AVRO_PROP_MAX_LENGTH,
+            false, false));
       } catch (Exception ex) {
         throw new AvroSerdeException("Failed to obtain maxLength value from file schema: " + schema, ex);
       }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
1. Usage of AvroCompatibilityHelper to replace deprecated Avro methods.
2. AvroCompatibilityHelper to help hive consumer easily migrate to the higher version of Avro.
3. Added https://linkedin.jfrog.io repository to pull avro-util dependency.
3. No need to upgrading from Jackson 1.x to Jackson 2.x as compatibility helper handles internally.
4. Changes are done on a branch created from branch-1.0.1.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
1. Gobblin currently uses hive 1.0.1 and the upgrade of Avro 1.9.2 is blocked due older version of Avro and Jackson on hive 1.0.1.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
No
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
1. Local build
2. Released a local snapshot and applied on Gobblin.
3. With these changes gobblin build failures coming from hive serde library is resolved and gobblin is able to use Avro 1.9.2 without any build failure.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
